### PR TITLE
Clear interval when nav unmounts

### DIFF
--- a/src/js/__tests__/components/navigation.js
+++ b/src/js/__tests__/components/navigation.js
@@ -71,6 +71,37 @@ describe('components/navigation.js', function () {
 
   });
 
+  it('should start an interval for refreshing notifications on mount & stop the interval on unmount', function () {
+    const props = {
+      isFetching: false,
+      notifications: notifications,
+      token: 'IMLOGGEDIN',
+      location: {
+        pathname: '/home'
+      }
+    };
+
+    const instance = {
+      props
+    };
+
+    const setIntervalSpy = sinon.spy(global, 'setInterval');
+    const clearIntervalSpy = sinon.spy(global, 'clearInterval');
+
+    Navigation.prototype.componentDidMount.call(instance);
+
+    expect(setIntervalSpy).to.have.been.called;
+    expect(instance.requestInterval).to.be.ok;
+
+    Navigation.prototype.componentWillUnmount.call(instance);
+
+    expect(clearIntervalSpy).to.have.been.called;
+    expect(clearIntervalSpy).to.have.been.calledWith(instance.requestInterval);
+
+    setIntervalSpy.restore();
+    clearIntervalSpy.restore();
+  });
+
   it('should load notifications after 60000ms', function () {
 
     const props = {

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -12,9 +12,13 @@ export class Navigation extends React.Component {
     var iFrequency = 60000;
     var myInterval = 0;
     if (myInterval > 0) { clearInterval(myInterval); }
-    setInterval( function () {
+    this.requestInterval = setInterval( function () {
       self.refreshNotifications();
     }, iFrequency );
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.requestInterval);
   }
 
   refreshNotifications() {

--- a/src/js/components/navigation.js
+++ b/src/js/components/navigation.js
@@ -10,8 +10,7 @@ export class Navigation extends React.Component {
   componentDidMount() {
     var self = this;
     var iFrequency = 60000;
-    var myInterval = 0;
-    if (myInterval > 0) { clearInterval(myInterval); }
+
     this.requestInterval = setInterval( function () {
       self.refreshNotifications();
     }, iFrequency );


### PR DESCRIPTION
This prevents a bug where after going on and offline for a while multiple intervals are started and causes a lot of requests, often resulting in rate-limiting.