### PR TITLE
Add Github enterprise support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceRoot}/main.js"
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to Process",
+            "address": "localhost",
+            "port": 5858
+        }
+    ]
+}

--- a/src/js/__tests__/actions/index.js
+++ b/src/js/__tests__/actions/index.js
@@ -33,7 +33,14 @@ describe('actions/index.js', () => {
       { type: actions.LOGIN.SUCCESS, payload: { body: { access_token: 'THISISATOKEN' } } }
     ];
 
-    const store = createMockStore({ response: [] }, expectedActions);
+    const store = createMockStore({
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      }),
+      response: []
+    }, expectedActions);
 
     return store.dispatch(actions.loginUser(code)).then(() => { // return of async actions
       expect(store.getActions()).toEqual(expectedActions);
@@ -57,7 +64,14 @@ describe('actions/index.js', () => {
       { type: actions.LOGIN.FAILURE, payload: { body: { message } } }
     ];
 
-    const store = createMockStore({ response: [] }, expectedActions);
+    const store = createMockStore({
+      response: [],
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      })
+    }, expectedActions);
 
     return store.dispatch(actions.loginUser(code)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
@@ -95,7 +109,11 @@ describe('actions/index.js', () => {
 
     const store = createMockStore({
       auth: Map({ token: 'THISISATOKEN' }),
-      settings: Map({ participating: false }),
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      }),
       notifications: Map({response: List()})
     }, expectedActions);
 
@@ -120,7 +138,11 @@ describe('actions/index.js', () => {
 
     const store = createMockStore({
       auth: Map({ token: null }),
-      settings: Map({ participating: false }),
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      }),
       notifications: Map({response: List()})
     }, expectedActions);
 
@@ -146,6 +168,11 @@ describe('actions/index.js', () => {
 
     const store = createMockStore({
       auth: Map({ token: 'IAMATOKEN' }),
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      }),
       notifications: Map({response: List()})
     }, expectedActions);
 
@@ -171,6 +198,11 @@ describe('actions/index.js', () => {
 
     const store = createMockStore({
       auth: Map({ token: null }),
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      }),
       notifications: Map({response: List()})
     }, expectedActions);
 
@@ -196,6 +228,11 @@ describe('actions/index.js', () => {
 
     const store = createMockStore({
       auth: Map({ token: 'IAMATOKEN' }),
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      }),
       notifications: Map({response: List()})
     }, expectedActions);
 
@@ -221,6 +258,11 @@ describe('actions/index.js', () => {
 
     const store = createMockStore({
       auth: Map({ token: null }),
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      }),
       notifications: Map({response: List()})
     }, expectedActions);
 
@@ -241,6 +283,11 @@ describe('actions/index.js', () => {
 
     const store = createMockStore({
       auth: Map({ token: 'IAMATOKEN' }),
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      }),
       notifications: Map({response: List()})
     }, expectedActions);
 
@@ -261,6 +308,11 @@ describe('actions/index.js', () => {
 
     const store = createMockStore({
       auth: Map({ token: 'IAMATOKEN' }),
+      settings: Map({
+        participating: false,
+        isEnterprise: false,
+        baseUrl: 'github.com'
+      }),
       notifications: Map({response: List()})
     }, expectedActions);
 

--- a/src/js/__tests__/components/login.js
+++ b/src/js/__tests__/components/login.js
@@ -39,6 +39,11 @@ describe('components/login.js', () => {
         token: '123456',
         failed: false,
         isFetching: false,
+        settings: Map({
+          baseUrl: 'github.com',
+          clientId: '3fef4433a29c6ad8f22c',
+          clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
+        }),
       }),
     };
 
@@ -55,7 +60,12 @@ describe('components/login.js', () => {
       token: null,
       response: {},
       failed: false,
-      isFetching: false
+      isFetching: false,
+      settings: Map({
+        baseUrl: 'github.com',
+        clientId: '3fef4433a29c6ad8f22c',
+        clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
+      }),
     };
 
     const { wrapper } = setup(props);
@@ -81,7 +91,12 @@ describe('components/login.js', () => {
       token: null,
       response: {},
       failed: false,
-      isFetching: false
+      isFetching: false,
+      settings: Map({
+        baseUrl: 'github.com',
+        clientId: '3fef4433a29c6ad8f22c',
+        clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
+      }),
     };
 
     const { wrapper } = setup(props);
@@ -113,7 +128,12 @@ describe('components/login.js', () => {
       token: null,
       response: {},
       failed: false,
-      isFetching: false
+      isFetching: false,
+      settings: Map({
+        baseUrl: 'github.com',
+        clientId: '3fef4433a29c6ad8f22c',
+        clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
+      }),
     };
 
     const { wrapper } = setup(props);
@@ -145,7 +165,12 @@ describe('components/login.js', () => {
       token: null,
       response: {},
       failed: false,
-      isFetching: false
+      isFetching: false,
+      settings: Map({
+        baseUrl: 'github.com',
+        clientId: '3fef4433a29c6ad8f22c',
+        clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
+      }),
     };
 
     const { wrapper } = setup(props);
@@ -176,7 +201,12 @@ describe('components/login.js', () => {
       token: null,
       response: {},
       failed: false,
-      isFetching: false
+      isFetching: false,
+      settings: Map({
+        baseUrl: 'github.com',
+        clientId: '3fef4433a29c6ad8f22c',
+        clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
+      }),
     };
 
     const { wrapper } = setup(props);
@@ -194,7 +224,12 @@ describe('components/login.js', () => {
       isLoggedIn: false,
       response: {},
       failed: false,
-      isFetching: false
+      isFetching: false,
+      settings: Map({
+        baseUrl: 'github.com',
+        clientId: '3fef4433a29c6ad8f22c',
+        clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
+      }),
     };
 
     const { wrapper, context } = setup(props);

--- a/src/js/__tests__/components/login.js
+++ b/src/js/__tests__/components/login.js
@@ -88,7 +88,7 @@ describe('components/login.js', () => {
 
     expect(wrapper).toBeDefined();
 
-    wrapper.find('.btn').simulate('click');
+    wrapper.find('.github').simulate('click');
 
     expect(BrowserWindow().loadURL).toHaveBeenCalledTimes(1);
     expect(BrowserWindow().loadURL).toHaveBeenCalledWith(expectedUrl);
@@ -120,7 +120,7 @@ describe('components/login.js', () => {
 
     expect(wrapper).toBeDefined();
 
-    wrapper.find('.btn').simulate('click');
+    wrapper.find('.github').simulate('click');
 
     expect(BrowserWindow().loadURL).toHaveBeenCalledTimes(1);
     expect(BrowserWindow().loadURL).toHaveBeenCalledWith(expectedUrl);
@@ -152,7 +152,7 @@ describe('components/login.js', () => {
 
     expect(wrapper).toBeDefined();
 
-    wrapper.find('.btn').simulate('click');
+    wrapper.find('.github').simulate('click');
 
     expect(BrowserWindow().loadURL).toHaveBeenCalledTimes(1);
     expect(BrowserWindow().loadURL).toHaveBeenCalledWith(expectedUrl);
@@ -183,7 +183,7 @@ describe('components/login.js', () => {
 
     expect(wrapper).toBeDefined();
 
-    wrapper.find('.btn').simulate('click');
+    wrapper.find('.github').simulate('click');
 
     expect(BrowserWindow().loadURL).toHaveBeenCalledTimes(1);
     expect(props.loginUser).not.toHaveBeenCalled();
@@ -209,25 +209,5 @@ describe('components/login.js', () => {
     expect(ipcRenderer.send).toHaveBeenCalledWith('reopen-window');
     expect(context.router.push).toHaveBeenCalledTimes(1);
     expect(context.router.push).toHaveBeenCalledWith('/notifications');
-  });
-
-  it('should request the github token if the oauth code is received', () => {
-    const code = 'thisisacode';
-
-    const props = {
-      loginUser: jest.fn(),
-      token: null,
-      response: {},
-      failed: false,
-      isFetching: false
-    };
-
-    const { wrapper } = setup(props);
-
-    expect(wrapper).toBeDefined();
-
-    wrapper.instance().requestGithubToken(code);
-    expect(props.loginUser).toHaveBeenCalledTimes(1);
-    expect(props.loginUser).toHaveBeenCalledWith(code);
   });
 });

--- a/src/js/__tests__/reducers/settings.js
+++ b/src/js/__tests__/reducers/settings.js
@@ -12,7 +12,11 @@ describe('reducers/settings.js', () => {
     openAtStartup: false,
     showSettingsModal: false,
     hasStarred: false,
-    showAppIcon: 'both'
+    showAppIcon: 'both',
+    isEnterprise: false,
+    baseUrl: 'github.com',
+    clientId: '3fef4433a29c6ad8f22c',
+    clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
   });
 
   it('should return the initial state', () => {

--- a/src/js/__tests__/routes.js
+++ b/src/js/__tests__/routes.js
@@ -15,7 +15,7 @@ describe('routes.js', () => {
 
     expect(routes).toBeDefined();
     expect(routes.props.path).toBe('/');
-    expect(routes.props.children.length).toBe(4);
+    expect(routes.props.children.length).toBe(5);
   });
 
   it('should return the routes (logged out)', () => {
@@ -24,7 +24,7 @@ describe('routes.js', () => {
 
     expect(routes).toBeDefined();
     expect(routes.props.path).toBe('/');
-    expect(routes.props.children.length).toBe(4);
+    expect(routes.props.children.length).toBe(5);
   });
 
   it('should render the NotFound component', () => {

--- a/src/js/__tests__/utils/helpers.js
+++ b/src/js/__tests__/utils/helpers.js
@@ -1,21 +1,23 @@
 import Helpers from '../../utils/helpers';
 
 describe('utils/helpers.js', () => {
+  const isEnterprise = false;
+
   it('should generate the GitHub url (issue)', () => {
     var apiUrl = 'https://api.github.com/repos/ekonstantinidis/notifications-test/issues/3';
-    var newUrl = Helpers.generateGitHubUrl(apiUrl);
+    var newUrl = Helpers.generateGitHubUrl(isEnterprise, apiUrl);
     expect(newUrl).toBe('https://www.github.com/ekonstantinidis/notifications-test/issues/3');
   });
 
   it('should generate the GitHub url (repos)', () => {
     var apiUrl = 'https://api.github.com/repos/ekonstantinidis/notifications-test/pulls/12345';
-    var newUrl = Helpers.generateGitHubUrl(apiUrl);
+    var newUrl = Helpers.generateGitHubUrl(isEnterprise, apiUrl);
     expect(newUrl).toBe('https://www.github.com/ekonstantinidis/notifications-test/pull/12345');
   });
 
   it('should generate the GitHub url (release)', () => {
     var apiUrl = 'https://api.github.com/repos/ekonstantinidis/notifications-test/releases/3988077';
-    var newUrl = Helpers.generateGitHubUrl(apiUrl);
+    var newUrl = Helpers.generateGitHubUrl(isEnterprise, apiUrl);
     expect(newUrl).toBe('https://www.github.com/ekonstantinidis/notifications-test/releases');
   });
 });

--- a/src/js/__tests__/utils/notifications.js
+++ b/src/js/__tests__/utils/notifications.js
@@ -169,7 +169,7 @@ describe('utils/notifications.js', () => {
 
     spyOn(comms, 'openExternalLink');
 
-    const nativeNotification = NotificationsUtils.raiseNativeNotification([notification]);
+    const nativeNotification = NotificationsUtils.raiseNativeNotification(false, [notification]);
     nativeNotification.onclick();
 
     const newUrl = Helpers.generateGitHubUrl(false, notification.subject.url);
@@ -203,7 +203,7 @@ describe('utils/notifications.js', () => {
 
     spyOn(comms, 'reOpenWindow');
 
-    const nativeNotification = NotificationsUtils.raiseNativeNotification(notifications);
+    const nativeNotification = NotificationsUtils.raiseNativeNotification(false, notifications);
     nativeNotification.onclick();
 
     expect(comms.reOpenWindow).toHaveBeenCalledTimes(1);

--- a/src/js/__tests__/utils/notifications.js
+++ b/src/js/__tests__/utils/notifications.js
@@ -172,7 +172,7 @@ describe('utils/notifications.js', () => {
     const nativeNotification = NotificationsUtils.raiseNativeNotification([notification]);
     nativeNotification.onclick();
 
-    const newUrl = Helpers.generateGitHubUrl(notification.subject.url);
+    const newUrl = Helpers.generateGitHubUrl(false, notification.subject.url);
     expect(comms.openExternalLink).toHaveBeenCalledTimes(1);
     expect(comms.openExternalLink).toHaveBeenCalledWith(newUrl);
   });

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -3,8 +3,8 @@ import { apiRequest, apiRequestAuth } from '../utils/api-requests';
 import Constants from '../utils/constants';
 
 function constructGithubUrl(settings) {
-  return `https://${settings.get('isEnterprise') ? '' : 'api.'}
-  ${settings.get('baseUrl')}${settings.get('isEnterprise') ? '/api/v3/' : '/'}`;
+  return `https://${settings.get('isEnterprise') ? '' : 'api.'}` +
+  `${settings.get('baseUrl')}${settings.get('isEnterprise') ? '/api/v3/' : '/'}`;
 }
 
 export function makeAsyncActionSet(actionName) {
@@ -53,11 +53,9 @@ export function logout() {
 export const NOTIFICATIONS = makeAsyncActionSet('NOTIFICATIONS');
 export function fetchNotifications() {
   return (dispatch, getState) => {
-
-    const participating = getState().settings.participating;
     const { settings } = getState();
     // Construct the api!
-    const url = `${constructGithubUrl(settings)}notifications?participating=${participating}`;
+    const url = `${constructGithubUrl(settings)}notifications?participating=${settings.get('participating')}`;
     const method = 'GET';
     const token = getState().auth.get('token');
 

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -3,7 +3,8 @@ import { apiRequest, apiRequestAuth } from '../utils/api-requests';
 import Constants from '../utils/constants';
 
 function constructGithubUrl(settings) {
-  return `https://${settings.get('isEnterprise') ? '' : 'api.'}${settings.get('baseUrl')}${settings.get('isEnterprise') ? '/api/v3/' : '/'}`;
+  return `https://${settings.get('isEnterprise') ? '' : 'api.'}
+  ${settings.get('baseUrl')}${settings.get('isEnterprise') ? '/api/v3/' : '/'}`;
 }
 
 export function makeAsyncActionSet(actionName) {

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -3,8 +3,7 @@ import { apiRequest, apiRequestAuth } from '../utils/api-requests';
 import Constants from '../utils/constants';
 
 function constructGithubUrl(settings) {
-  return `https://${settings.get('isEnterprise') ? '' : 'api.'}
-    ${settings.get('baseUrl')}${settings.get('isEnterprise') ? '/api/v3/' : '/'}`;
+  return `https://${settings.get('isEnterprise') ? '' : 'api.'}${settings.get('baseUrl')}${settings.get('isEnterprise') ? '/api/v3/' : '/'}`;
 }
 
 export function makeAsyncActionSet(actionName) {
@@ -30,7 +29,7 @@ export function loginUser(code) {
     };
 
     dispatch({type: LOGIN.REQUEST});
-
+    debugger;
     return apiRequest(url, method, data)
       .then(function (response) {
         dispatch({type: LOGIN.SUCCESS, payload: response.data});

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -2,6 +2,10 @@ import { apiRequest, apiRequestAuth } from '../utils/api-requests';
 
 import Constants from '../utils/constants';
 
+function constructGithubUrl(settings) {
+  return `https://${settings.isEnterprise ? '' : 'api.'}${settings.baseUrl}${settings.isEnterprise ? '/api/v3/' : '/'}`;
+}
+
 export function makeAsyncActionSet(actionName) {
   return {
     REQUEST: actionName + '_REQUEST',
@@ -15,12 +19,12 @@ export function makeAsyncActionSet(actionName) {
 export const LOGIN = makeAsyncActionSet('LOGIN');
 export function loginUser(code) {
   return (dispatch, getState) => {
-
-    const url = 'https://github.com/login/oauth/access_token';
+    const { settings } = getState();
+    const url = `https://${settings.baseUrl}/login/oauth/access_token`;
     const method = 'POST';
     const data = {
-      'client_id': Constants.CLIENT_ID,
-      'client_secret': Constants.CLIENT_SECRET,
+      'client_id': settings.clientId,
+      'client_secret': settings.clientSecret,
       'code': code
     };
 
@@ -49,8 +53,10 @@ export const NOTIFICATIONS = makeAsyncActionSet('NOTIFICATIONS');
 export function fetchNotifications() {
   return (dispatch, getState) => {
 
-    const participating = getState().settings.get('participating');
-    const url = `https://api.github.com/notifications?participating=${participating}`;
+    const participating = getState().settings.participating;
+    const { settings } = getState();
+    // Construct the api!
+    const url = `${constructGithubUrl(settings)}notifications?participating=${participating}`;
     const method = 'GET';
     const token = getState().auth.get('token');
 
@@ -73,8 +79,9 @@ export function fetchNotifications() {
 export const MARK_NOTIFICATION = makeAsyncActionSet('MARK_NOTIFICATION');
 export function markNotification(id) {
   return (dispatch, getState) => {
-
-    const url = `https://api.github.com/notifications/threads/${id}`;
+    const { settings } = getState();
+    // Construct the api!
+    const url = `${constructGithubUrl(settings)}notifications/threads/${id}`;
     const method = 'PATCH';
     const token = getState().auth.get('token');
 
@@ -97,7 +104,9 @@ export const MARK_REPO_NOTIFICATION = makeAsyncActionSet('MARK_REPO_NOTIFICATION
 export function markRepoNotifications(repoSlug) {
   return (dispatch, getState) => {
 
-    const url = `https://api.github.com/repos/${repoSlug}/notifications`;
+    const { settings } = getState();
+    // Construct the api!
+    const url = `${constructGithubUrl(settings)}repos/${repoSlug}/notifications`;
     const method = 'PUT';
     const token = getState().auth.get('token');
 
@@ -119,8 +128,9 @@ export function markRepoNotifications(repoSlug) {
 export const HAS_STARRED = makeAsyncActionSet('HAS_STARRED');
 export function checkHasStarred() {
   return (dispatch, getState) => {
-
-    const url = `https://api.github.com/user/starred/${Constants.REPO_SLUG}`;
+    const { settings } = getState();
+    // Construct the api!
+    const url = `${constructGithubUrl(settings)}user/starred/${Constants.REPO_SLUG}`;
     const method = 'GET';
     const token = getState().auth.get('token');
 

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -3,7 +3,8 @@ import { apiRequest, apiRequestAuth } from '../utils/api-requests';
 import Constants from '../utils/constants';
 
 function constructGithubUrl(settings) {
-  return `https://${settings.isEnterprise ? '' : 'api.'}${settings.baseUrl}${settings.isEnterprise ? '/api/v3/' : '/'}`;
+  return `https://${settings.get('isEnterprise') ? '' : 'api.'}
+    ${settings.get('baseUrl')}${settings.get('isEnterprise') ? '/api/v3/' : '/'}`;
 }
 
 export function makeAsyncActionSet(actionName) {
@@ -20,11 +21,11 @@ export const LOGIN = makeAsyncActionSet('LOGIN');
 export function loginUser(code) {
   return (dispatch, getState) => {
     const { settings } = getState();
-    const url = `https://${settings.baseUrl}/login/oauth/access_token`;
+    const url = `https://${settings.get('baseUrl')}/login/oauth/access_token`;
     const method = 'POST';
     const data = {
-      'client_id': settings.clientId,
-      'client_secret': settings.clientSecret,
+      'client_id': settings.get('clientId'),
+      'client_secret': settings.get('clientSecret'),
       'code': code
     };
 

--- a/src/js/components/enterprise-login.js
+++ b/src/js/components/enterprise-login.js
@@ -13,6 +13,7 @@ class EnterpriseLogin extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const isLoggedIn = nextProps.token !== null;
+    debugger;
     if (isLoggedIn) {
       ipcRenderer.send('reopen-window');
       this.context.router.push('/notifications');
@@ -92,7 +93,7 @@ class EnterpriseLogin extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    token: state.auth.token,
+    token: state.auth.get('token'),
     settings: state.settings
   };
 };

--- a/src/js/components/enterprise-login.js
+++ b/src/js/components/enterprise-login.js
@@ -1,0 +1,103 @@
+var ipcRenderer = window.require('electron').ipcRenderer;
+
+import React from 'react';
+import helpers from '../utils/helpers';
+import { connect } from 'react-redux';
+import { updateSetting, loginUser } from '../actions';
+
+class EnterpriseLogin extends React.Component {
+
+  static contextTypes = {
+    router: React.PropTypes.object.isRequired
+  };
+
+  componentWillReceiveProps(nextProps) {
+    const isLoggedIn = nextProps.token !== null;
+    if (isLoggedIn) {
+      ipcRenderer.send('reopen-window');
+      this.context.router.push('/notifications');
+    }
+  }
+
+  componentDidMount() {
+    // We want to know whether or not we are loading as enterprise
+    this.props.updateSetting('isEnterprise', true);
+  }
+
+  toggleSetting(key, event) {
+    this.props.updateSetting(key, event.target.value);
+  }
+
+  handleLoginClick = () => {
+    helpers.authGithub(this.props.settings, this.props.loginUser);
+  }
+
+  routeToLogin = () => {
+    this.context.router.push('/login');
+  }
+
+  render() {
+    return (
+      <div className="container-fluid main-container settings">
+        <ul className="nav nav-pills">
+          <li className="nav-item">
+            <a className="nav-link" onClick={this.routeToLogin}>
+              <i className="fa fa-arrow-left" /> Back to login page
+            </a>
+          </li>
+        </ul>
+
+        <div className="row setting">
+          <div className="col-xs-4">Base Url</div>
+          <div className="col-xs-8">
+            <input
+              className="form-control"
+              placeholder="github.company.com"
+              onChange={this.toggleSetting.bind(this, 'baseUrl')}
+            />
+          </div>
+        </div>
+        <div className="row setting">
+          <div className="col-xs-4">Client ID</div>
+          <div className="col-xs-8">
+            <input
+              className="form-control"
+              placeholder="24084b7c891c8a7a0385"
+              onChange={this.toggleSetting.bind(this, 'clientId')}
+            />
+          </div>
+        </div>
+        <div className="row setting">
+          <div className="col-xs-4">Secret</div>
+          <div className="col-xs-8">
+            <input
+              className="form-control"
+              placeholder="177537vsrh5u54u2ht43y2yfhsr"
+              onChange={this.toggleSetting.bind(this, 'clientSecret')}
+            />
+          </div>
+        </div>
+
+        <div className="row footer">
+          <div className="col-xs-12 text-center">
+            <button className="btn btn-md" onClick={this.handleLoginClick}>
+              <i className="fa fa-github" />Login to GitHub enterprise
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    token: state.auth.token,
+    settings: state.settings
+  };
+};
+
+export default connect(mapStateToProps, {
+  updateSetting,
+  loginUser
+})(EnterpriseLogin);

--- a/src/js/components/enterprise-login.js
+++ b/src/js/components/enterprise-login.js
@@ -1,4 +1,4 @@
-var ipcRenderer = window.require('electron').ipcRenderer;
+var ipcRenderer = require('electron').ipcRenderer;
 
 import React from 'react';
 import helpers from '../utils/helpers';

--- a/src/js/components/login.js
+++ b/src/js/components/login.js
@@ -37,16 +37,18 @@ export class LoginPage extends React.Component {
             <img className="img-responsive logo" src="images/gitify-logo-outline-dark.png" />
             <div className="desc">GitHub Notifications<br />in your menu bar.</div>
             <div className="row">
-              <div className="col-xs-6 login-btn">
-                <button className="btn btn-md" onClick={helpers.authGithub.bind(this, this.props.settings, this.props.loginUser)}>
-                  <i className="fa fa-github" />GitHub
-                </button>
-              </div>
-              <div className="col-xs-6 login-btn">
-                <button className="btn btn-md" onClick={this.routeToEnterpriseLogin}>
-                  <i className="fa fa-github" />Enterprise
-                </button>
-              </div>
+              <button
+                className="btn btn-lg btn-block"
+                onClick={helpers.authGithub.bind(this, this.props.settings, this.props.loginUser)}
+              >
+                <i className="fa fa-github" /> Log in to GitHub
+              </button>
+              <button
+                  className="btn btn-lg btn-block"
+                  onClick={this.routeToEnterpriseLogin}
+              >
+                <i className="fa fa-github" /> Enterprise
+              </button>
             </div>
           </div>
         </div>

--- a/src/js/components/login.js
+++ b/src/js/components/login.js
@@ -1,5 +1,4 @@
-const { ipcRenderer, remote } = require('electron');
-const BrowserWindow = remote.BrowserWindow;
+const { ipcRenderer } = require('electron');
 
 import React from 'react';
 import { connect } from 'react-redux';

--- a/src/js/components/login.js
+++ b/src/js/components/login.js
@@ -37,13 +37,13 @@ export class LoginPage extends React.Component {
             <div className="desc">GitHub Notifications<br />in your menu bar.</div>
             <div className="row">
               <button
-                className="btn btn-lg btn-block"
+                className="btn btn-lg btn-block github"
                 onClick={helpers.authGithub.bind(this, this.props.settings, this.props.loginUser)}
               >
                 <i className="fa fa-github" /> Log in to GitHub
               </button>
               <button
-                  className="btn btn-lg btn-block"
+                  className="btn btn-lg btn-block enterprise"
                   onClick={this.routeToEnterpriseLogin}
               >
                 <i className="fa fa-github" /> Enterprise

--- a/src/js/components/login.js
+++ b/src/js/components/login.js
@@ -3,11 +3,21 @@ const BrowserWindow = remote.BrowserWindow;
 
 import React from 'react';
 import { connect } from 'react-redux';
+import helpers from '../utils/helpers';
 
-import { loginUser } from '../actions';
-import Constants from '../utils/constants';
+import { updateSetting, loginUser } from '../actions';
 
 export class LoginPage extends React.Component {
+
+  componentDidMount() {
+    // TODO: Find a way to batch this....
+    // Reset settings to default github info
+    this.props.updateSetting('isEnterprise', false);
+    this.props.updateSetting('baseUrl', 'github.com');
+    this.props.updateSetting('clientId', '3fef4433a29c6ad8f22c');
+    this.props.updateSetting('clientSecret', '9670de733096c15322183ff17ed0fc8704050379');
+  }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.isLoggedIn) {
       ipcRenderer.send('reopen-window');
@@ -15,57 +25,8 @@ export class LoginPage extends React.Component {
     }
   }
 
-  authGithub () {
-    var self = this;
-
-    //Build the OAuth consent page URL
-    var authWindow = new BrowserWindow({
-      width: 800,
-      height: 600,
-      show: true,
-      webPreferences: {
-        nodeIntegration: false
-      }
-    });
-    var githubUrl = 'https://github.com/login/oauth/authorize?';
-    var authUrl = githubUrl + 'client_id=' + Constants.CLIENT_ID + '&scope=' + Constants.SCOPE;
-    authWindow.loadURL(authUrl);
-
-    function handleCallback (url) {
-      var raw_code = /code=([^&]*)/.exec(url) || null;
-      var code = (raw_code && raw_code.length > 1) ? raw_code[1] : null;
-      var error = /\?error=(.+)$/.exec(url);
-
-      if (code || error) {
-        // Close the browser if code found or error
-        authWindow.destroy();
-      }
-
-      // If there is a code, proceed to get token from github
-      if (code) {
-        self.requestGithubToken(code);
-      } else if (error) {
-        alert('Oops! Something went wrong and we couldn\'t ' +
-          'log you in using Github. Please try again.');
-      }
-    }
-
-    // If "Done" button is pressed, hide "Loading"
-    authWindow.on('close', function () {
-      authWindow.destroy();
-    });
-
-    authWindow.webContents.on('will-navigate', function (event, url) {
-      handleCallback(url);
-    });
-
-    authWindow.webContents.on('did-get-redirect-request', function (event, oldUrl, newUrl) {
-      handleCallback(newUrl);
-    });
-  }
-
-  requestGithubToken(code) {
-    this.props.loginUser(code);
+  routeToEnterpriseLogin = () => {
+    this.context.router.push('/enterpriselogin');
   }
 
   render() {
@@ -75,9 +36,18 @@ export class LoginPage extends React.Component {
           <div className="offset-xs-2 col-xs-8">
             <img className="img-responsive logo" src="images/gitify-logo-outline-dark.png" />
             <div className="desc">GitHub Notifications<br />in your menu bar.</div>
-            <button className="btn btn-lg btn-block" onClick={this.authGithub.bind(this)}>
-              <i className="fa fa-github" />Log in to GitHub
-            </button>
+            <div className="row">
+              <div className="col-xs-6 login-btn">
+                <button className="btn btn-md" onClick={helpers.authGithub.bind(this, this.props.settings, this.props.loginUser)}>
+                  <i className="fa fa-github" />GitHub
+                </button>
+              </div>
+              <div className="col-xs-6 login-btn">
+                <button className="btn btn-md" onClick={this.routeToEnterpriseLogin}>
+                  <i className="fa fa-github" />Enterprise
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -93,8 +63,9 @@ export function mapStateToProps(state) {
   return {
     isLoggedIn: state.auth.get('token') !== null,
     failed: state.auth.get('failed'),
-    isFetching: state.auth.get('isFetching')
+    isFetching: state.auth.get('isFetching'),
+    settings: state.settings
   };
 };
 
-export default connect(mapStateToProps, { loginUser })(LoginPage);
+export default connect(mapStateToProps, { updateSetting, loginUser })(LoginPage);

--- a/src/js/components/notification.js
+++ b/src/js/components/notification.js
@@ -72,7 +72,7 @@ export class SingleNotification extends React.Component {
 export function mapStateToProps(state) {
   return {
     markOnClick: state.settings.get('markOnClick'),
-    isEnterprise: state.settings.isEnterprise
+    isEnterprise: state.settings.get('isEnterprise')
   };
 };
 

--- a/src/js/components/notification.js
+++ b/src/js/components/notification.js
@@ -18,7 +18,7 @@ export class SingleNotification extends React.Component {
   }
 
   openBrowser() {
-    var url = Helpers.generateGitHubUrl(this.props.notification.getIn(['subject', 'url']));
+    var url = Helpers.generateGitHubUrl(this.props.isEnterprise, this.props.notification.getIn(['subject', 'url']));
     shell.openExternal(url);
   }
 
@@ -72,6 +72,7 @@ export class SingleNotification extends React.Component {
 export function mapStateToProps(state) {
   return {
     markOnClick: state.settings.get('markOnClick'),
+    isEnterprise: state.settings.isEnterprise
   };
 };
 

--- a/src/js/reducers/settings.js
+++ b/src/js/reducers/settings.js
@@ -14,7 +14,7 @@ const initialState = Map({
   baseUrl: 'github.com',
   clientId: '3fef4433a29c6ad8f22c',
   clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
-};
+});
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {

--- a/src/js/reducers/settings.js
+++ b/src/js/reducers/settings.js
@@ -10,7 +10,11 @@ const initialState = Map({
   showSettingsModal: false,
   hasStarred: false,
   showAppIcon: 'both',
-});
+  isEnterprise: false,
+  baseUrl: 'github.com',
+  clientId: '3fef4433a29c6ad8f22c',
+  clientSecret: '9670de733096c15322183ff17ed0fc8704050379'
+};
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -3,6 +3,7 @@ import { Route, IndexRoute } from 'react-router';
 
 import App from './containers/app';
 import LoginPage from './components/login';
+import EnterpriseLoginPage from './components/enterprise-login';
 import NotificationsPage from './components/notifications';
 
 export class NotFound extends React.Component {
@@ -26,6 +27,7 @@ export default (store) => {
       <IndexRoute component={NotificationsPage} onEnter={requireAuth(store)} />
       <Route path="/notifications" component={NotificationsPage} />
       <Route path="/login" component={LoginPage} />
+      <Route path="/enterpriselogin" component={EnterpriseLoginPage} />
       <Route path="*" component={NotFound} />
     </Route>
   );

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -1,7 +1,4 @@
-let constants = {
-  // GitHub OAuth
-  CLIENT_ID: '3fef4433a29c6ad8f22c',
-  CLIENT_SECRET: '9670de733096c15322183ff17ed0fc8704050379',
+const constants = {
   SCOPE: ['user:email', 'notifications'],
 
   REPO_SLUG: 'manosim/gitify',

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -1,5 +1,4 @@
 var electron = window.require('electron');
-const ipcRenderer = window.require('electron').ipcRenderer;
 var remote = electron.remote;
 var BrowserWindow = remote.BrowserWindow;
 

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -1,4 +1,4 @@
-var electron = window.require('electron');
+var electron = require('electron');
 var remote = electron.remote;
 var BrowserWindow = remote.BrowserWindow;
 
@@ -22,7 +22,7 @@ export default {
     return newUrl;
   },
 
-  authGithub (settings, loginUser) {
+  authGithub(settings, loginUser) {
     //Build the OAuth consent page URL
     var authWindow = new BrowserWindow({
       width: 800,

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -33,8 +33,8 @@ export default {
         nodeIntegration: false
       }
     });
-    var githubUrl = `https://${settings.baseUrl}/login/oauth/authorize?`;
-    var authUrl = githubUrl + 'client_id=' + settings.clientId + '&scope=' + Constants.SCOPE;
+    var githubUrl = `https://${settings.get('baseUrl')}/login/oauth/authorize?`;
+    var authUrl = githubUrl + 'client_id=' + settings.get('clientId') + '&scope=' + Constants.SCOPE;
     authWindow.loadURL(authUrl);
 
     function handleCallback (url) {

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -1,6 +1,15 @@
+var electron = window.require('electron');
+const ipcRenderer = window.require('electron').ipcRenderer;
+var remote = electron.remote;
+var BrowserWindow = remote.BrowserWindow;
+
+import Constants from './constants';
+
 export default {
-  generateGitHubUrl(url) {
-    var newUrl = url.replace('api.github.com/repos', 'www.github.com');
+  generateGitHubUrl(isEnterprise, url) {
+    let newUrl = isEnterprise
+      ? url.replace('github.intuit.com/api/v3/repos', 'github.intuit.com')
+      : url.replace('api.github.com/repos', 'www.github.com');
 
     if (newUrl.indexOf('/pulls/') !== -1) {
       newUrl = newUrl.replace('/pulls/', '/pull/');
@@ -12,5 +21,52 @@ export default {
     }
 
     return newUrl;
+  },
+
+  authGithub (settings, loginUser) {
+    //Build the OAuth consent page URL
+    var authWindow = new BrowserWindow({
+      width: 800,
+      height: 600,
+      show: true,
+      webPreferences: {
+        nodeIntegration: false
+      }
+    });
+    var githubUrl = `https://${settings.baseUrl}/login/oauth/authorize?`;
+    var authUrl = githubUrl + 'client_id=' + settings.clientId + '&scope=' + Constants.SCOPE;
+    authWindow.loadURL(authUrl);
+
+    function handleCallback (url) {
+      var raw_code = /code=([^&]*)/.exec(url) || null;
+      var code = (raw_code && raw_code.length > 1) ? raw_code[1] : null;
+      var error = /\?error=(.+)$/.exec(url);
+
+      if (code || error) {
+        // Close the browser if code found or error
+        authWindow.destroy();
+      }
+
+      // If there is a code, proceed to get token from github
+      if (code) {
+        loginUser(code);
+      } else if (error) {
+        alert('Oops! Something went wrong and we couldn\'t ' +
+          'log you in using Github. Please try again.');
+      }
+    }
+
+    // If "Done" button is pressed, hide "Loading"
+    authWindow.on('close', function () {
+      authWindow.destroy();
+    });
+
+    authWindow.webContents.on('will-navigate', function (event, url) {
+      handleCallback(url);
+    });
+
+    authWindow.webContents.on('did-get-redirect-request', function (event, oldUrl, newUrl) {
+      handleCallback(newUrl);
+    });
   }
 };

--- a/src/js/utils/notifications.js
+++ b/src/js/utils/notifications.js
@@ -26,7 +26,7 @@ export default {
     }
 
     if (settings.get('showNotifications')) {
-      this.raiseNativeNotification(settings.isEnterprise, notifications);
+      this.raiseNativeNotification(settings.get('isEnterprise'), notifications);
     }
   },
 

--- a/src/js/utils/notifications.js
+++ b/src/js/utils/notifications.js
@@ -26,11 +26,11 @@ export default {
     }
 
     if (settings.get('showNotifications')) {
-      this.raiseNativeNotification(notifications);
+      this.raiseNativeNotification(settings.isEnterprise, notifications);
     }
   },
 
-  raiseNativeNotification(notifications) {
+  raiseNativeNotification(isEnterprise, notifications) {
     const newCount = notifications.length;
     const title = (newCount === 1 ? 'Gitify - ' + notifications[0].repository.full_name : 'Gitify');
     const body = (newCount === 1 ? notifications[0].subject.title : 'You\'ve got ' + newCount + ' notifications.');
@@ -43,7 +43,7 @@ export default {
 
     nativeNotification.onclick = function () {
       if (newCount === 1) {
-        var url = Helpers.generateGitHubUrl(notifications[0].subject.url);
+        var url = Helpers.generateGitHubUrl(isEnterprise, notifications[0].subject.url);
         openExternalLink(url);
       } else {
         reOpenWindow();

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -101,19 +101,6 @@ body {
 }
 
 .btn {
-<<<<<<< Updated upstream
-=======
-  @include border-radius(0);
-  border: 0;
-
-  @include button-variant($white, $gray, $btn-primary-border);
-  // padding: .55rem 1.25rem;
-
-  .fa {
-    margin-right: 10px;
-  }
-
->>>>>>> Stashed changes
   &:focus {
     outline: none;
   }

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -101,6 +101,19 @@ body {
 }
 
 .btn {
+<<<<<<< Updated upstream
+=======
+  @include border-radius(0);
+  border: 0;
+
+  @include button-variant($white, $gray, $btn-primary-border);
+  // padding: .55rem 1.25rem;
+
+  .fa {
+    margin-right: 10px;
+  }
+
+>>>>>>> Stashed changes
   &:focus {
     outline: none;
   }

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -101,6 +101,16 @@ body {
 }
 
 .btn {
+  @include border-radius(0);
+  border: 0;
+
+  @include button-variant($white, $gray, $btn-primary-border);
+  padding: .55rem 1.25rem;
+
+  .fa {
+    margin-right: 10px;
+  }
+
   &:focus {
     outline: none;
   }
@@ -109,6 +119,10 @@ body {
 .right,
 .text-right {
   text-align: right;
+}
+
+.text-center {
+  text-align: center;
 }
 
 input {
@@ -351,9 +365,8 @@ input {
     font-size: 20px;
   }
 
-  .btn {
-    @include button-variant($white, $gray, $btn-primary-border);
-    padding: .55rem 1.25rem;
+  .login-btn {
+    padding: 5px 0;
   }
 }
 

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -101,16 +101,6 @@ body {
 }
 
 .btn {
-  @include border-radius(0);
-  border: 0;
-
-  @include button-variant($white, $gray, $btn-primary-border);
-  padding: .55rem 1.25rem;
-
-  .fa {
-    margin-right: 10px;
-  }
-
   &:focus {
     outline: none;
   }
@@ -367,6 +357,11 @@ input {
 
   .login-btn {
     padding: 5px 0;
+  }
+
+  .btn {
+    @include button-variant($white, $gray, $btn-primary-border);
+    padding: .55rem 1.25rem;
   }
 }
 


### PR DESCRIPTION
This is my first pass at adding a functioning enterprise support by adding these two screens

<table>
  <tr>
    <th>New Login Page</th>
    <th>Enterprise Login Page</th>
  </tr>
  <tr>
    <td>
      <img src="https://cloud.githubusercontent.com/assets/10842162/24180025/e0e6ee42-0e6f-11e7-9750-aa2e84f4ee58.png" />
    </td>
    <td>
       <img src="https://cloud.githubusercontent.com/assets/10842162/24180049/f80bf720-0e6f-11e7-8629-420e356caaaa.png" />
    </td>
  </tr>
</table>

This PR still needs the following:
- [ ] General Code Review stuff
- [x] Getting old tests to run
- [ ] New tests
- [ ] General cleanup
