### PR TITLE
Remove `www.` on non-www URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 ### Download
-You can download Gitify for **free** from either the website [www.gitify.io](http://www.gitify.io/) or from the GitHub repository [releases](https://github.com/manosim/gitify/releases) page.
+You can download Gitify for **free** from either the website [gitify.io](http://gitify.io/) or from the GitHub repository [releases](https://github.com/manosim/gitify/releases) page.
 
 You can also install Gitify via [Homebrew Cask](http://caskroom.io/)
 
@@ -14,13 +14,13 @@ You can also install Gitify via [Homebrew Cask](http://caskroom.io/)
 brew cask install gitify
 ```
 
-Gitify currently only supports OS X.
+Gitify currently only supports macOS.
 
 
 ### Prerequisites
 
  - Node 6+
- - [Electron](http://electron.atom.io/)
+ - [Electron](https://electron.atom.io/)
  - [React](https://facebook.github.io/react/)
  - [Redux](http://redux.js.org/)
 
@@ -51,7 +51,7 @@ To prepare the app for distribution run:
 
     npm run package
 
-To publish a new version, you also need to codesign the app running `npm run codesign`. Currently supports only OS X.
+To publish a new version, you also need to codesign the app running `npm run codesign`. Currently supports only macOS.
 
 
 ### Tests
@@ -95,4 +95,4 @@ Gitify is licensed under the MIT Open Source license. For more information, see 
 [codecov-image]: https://codecov.io/gh/manosim/gitify/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/manosim/gitify
 [downloads-image]: https://img.shields.io/github/downloads/manosim/gitify/total.svg
-[downloads-url]: http://www.gitify.io
+[downloads-url]: http://gitify.io/

--- a/electron/app-menu-template.js
+++ b/electron/app-menu-template.js
@@ -78,7 +78,7 @@ const appMenuTemplate = [
       },
       {
         label: 'Visit Website',
-        click () { shell.openExternal('http://www.gitify.io'); }
+        click () { shell.openExternal('http://gitify.io/'); }
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "bugs": {
     "url": "https://github.com/manosim/gitify/issues"
   },
-  "homepage": "http://www.gitify.io/",
+  "homepage": "http://gitify.io/",
   "jest": {
     "coverageThreshold": {
       "global": {

--- a/src/js/__tests__/routes/enterprise-login.js
+++ b/src/js/__tests__/routes/enterprise-login.js
@@ -116,7 +116,7 @@ describe('routes/enterprise-login.js', () => {
 
     spyOn(BrowserWindow().webContents, 'on').and.callFake((event, callback) => {
       if (event === 'will-navigate') {
-        callback('will-navigate', `http://www.github.com/?code=${code}`);
+        callback('will-navigate', `https://github.com/?code=${code}`);
       }
     });
 

--- a/src/js/__tests__/routes/login.js
+++ b/src/js/__tests__/routes/login.js
@@ -59,7 +59,7 @@ describe('components/login.js', () => {
 
     spyOn(BrowserWindow().webContents, 'on').and.callFake((event, callback) => {
       if (event === 'will-navigate') {
-        callback('will-navigate', `http://www.github.com/?code=${code}`);
+        callback('will-navigate', `https://github.com/?code=${code}`);
       }
     });
 
@@ -91,7 +91,7 @@ describe('components/login.js', () => {
         callback(
           'did-get-redirect-request',
           null,
-          `http://www.github.com/?code=${code}`
+          `https://github.com/?code=${code}`
         );
       }
     });
@@ -124,7 +124,7 @@ describe('components/login.js', () => {
         callback(
           'did-get-redirect-request',
           null,
-          `http://www.github.com/?error=${error}`
+          `https://github.com/?error=${error}`
         );
       }
     });

--- a/src/js/__tests__/utils/comms.js
+++ b/src/js/__tests__/utils/comms.js
@@ -40,9 +40,9 @@ describe('utils/comms.js', () => {
   });
 
   it('should open an external link', () => {
-    openExternalLink('http://www.gitify.io/');
+    openExternalLink('http://gitify.io/');
     expect(shell.openExternal).toHaveBeenCalledTimes(1);
-    expect(shell.openExternal).toHaveBeenCalledWith('http://www.gitify.io/');
+    expect(shell.openExternal).toHaveBeenCalledWith('http://gitify.io/');
   });
 
   it('should setAutoLaunch (true)', () => {

--- a/src/js/__tests__/utils/helpers.js
+++ b/src/js/__tests__/utils/helpers.js
@@ -6,7 +6,7 @@ describe('utils/helpers.js', () => {
       'https://api.github.com/repos/ekonstantinidis/notifications-test/issues/3';
     const newUrl = generateGitHubWebUrl(apiUrl);
     expect(newUrl).toBe(
-      'https://www.github.com/ekonstantinidis/notifications-test/issues/3'
+      'https://github.com/ekonstantinidis/notifications-test/issues/3'
     );
   });
 
@@ -15,7 +15,7 @@ describe('utils/helpers.js', () => {
       'https://api.github.com/repos/ekonstantinidis/notifications-test/pulls/123';
     const newUrl = generateGitHubWebUrl(apiUrl);
     expect(newUrl).toBe(
-      'https://www.github.com/ekonstantinidis/notifications-test/pull/123'
+      'https://github.com/ekonstantinidis/notifications-test/pull/123'
     );
   });
 
@@ -23,9 +23,7 @@ describe('utils/helpers.js', () => {
     const apiUrl =
       'https://api.github.com/repos/myorg/notifications-test/releases/3988077';
     const newUrl = generateGitHubWebUrl(apiUrl);
-    expect(newUrl).toBe(
-      'https://www.github.com/myorg/notifications-test/releases'
-    );
+    expect(newUrl).toBe('https://github.com/myorg/notifications-test/releases');
   });
 
   it('should generate the GitHub url - enterprise - (issue)', () => {

--- a/src/js/components/sidebar.js
+++ b/src/js/components/sidebar.js
@@ -48,7 +48,7 @@ export class Sidebar extends React.Component {
   }
 
   onOpenBrowser() {
-    shell.openExternal(`https://www.github.com/${Constants.REPO_SLUG}`);
+    shell.openExternal(`https://github.com/${Constants.REPO_SLUG}`);
   }
 
   _renderGitHubAccount() {

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -25,7 +25,7 @@ export function generateGitHubWebUrl(url) {
 
   let newUrl = isEnterprise
     ? url.replace(`${hostname}/api/v3/repos`, hostname)
-    : url.replace('api.github.com/repos', 'www.github.com');
+    : url.replace('api.github.com/repos', 'github.com');
 
   if (newUrl.indexOf('/pulls/') !== -1) {
     newUrl = newUrl.replace('/pulls/', '/pull/');


### PR DESCRIPTION
Cuts down on unnecessary redirects.

- Consistently use HTTPS where appropriate for same reason