### PR TITLE
fix: only try to open links if non-null url

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettier": "prettier --single-quote --trailing-comma es5 --write 'src/**/*.{js,ts,tsx}'",
     "jest": "jest",
     "test": "yarn jest",
-    "start": "electron . –enable-logging"
+    "start": "electron . -–enable-logging"
   },
   "repository": {
     "type": "git",

--- a/src/js/components/notification.tsx
+++ b/src/js/components/notification.tsx
@@ -79,8 +79,11 @@ export const NotificationItem: React.FC<IProps> = (props) => {
   };
 
   const openBrowser = () => {
-    const url = generateGitHubWebUrl(props.notification.subject.url);
-    shell.openExternal(url);
+    // Some Notification types from GitHub are missing urls in their subjects.
+    if (props.notification.subject.url) {
+      const url = generateGitHubWebUrl(props.notification.subject.url);
+      shell.openExternal(url);
+    }
   };
 
   const markAsRead = () => {

--- a/src/js/utils/helpers.ts
+++ b/src/js/utils/helpers.ts
@@ -7,7 +7,7 @@ import Constants from './constants';
 import { loginUser } from '../actions';
 import { AuthState } from '../../types/reducers';
 
-export function getEnterpriseAccountToken(hostname, accounts) {
+export function getEnterpriseAccountToken(hostname, accounts): string {
   return accounts.find((obj) => obj.hostname === hostname).token;
 }
 
@@ -18,12 +18,12 @@ export function generateGitHubAPIUrl(hostname) {
     : `https://api.${hostname}/`;
 }
 
-export function generateGitHubWebUrl(url) {
+export function generateGitHubWebUrl(url: string) {
   const { hostname } = parse(url);
   const isEnterprise =
     hostname !== `api.${Constants.DEFAULT_AUTH_OPTIONS.hostname}`;
 
-  let newUrl = isEnterprise
+  let newUrl: string = isEnterprise
     ? url.replace(`${hostname}/api/v3/repos`, hostname)
     : url.replace('api.github.com/repos', 'github.com');
 

--- a/src/js/utils/notifications.ts
+++ b/src/js/utils/notifications.ts
@@ -2,11 +2,15 @@ const { remote } = require('electron');
 
 import { generateGitHubWebUrl } from '../utils/helpers';
 import { reOpenWindow, openExternalLink } from '../utils/comms';
-import { SubjectType } from '../../types/github';
+import { Notification } from '../../types/github';
 import { SettingsState } from '../../types/reducers';
 
 export default {
-  setup(notifications, notificationsCount, settings: SettingsState) {
+  setup(
+    notifications: Notification[],
+    notificationsCount,
+    settings: SettingsState
+  ) {
     // If there are no new notifications just stop there
     if (!notificationsCount) {
       return;
@@ -21,11 +25,15 @@ export default {
     }
   },
 
-  raiseNativeNotification(notifications, count) {
-    let title, body, icon, notificationUrl;
+  raiseNativeNotification(notifications, count: number) {
+    let title: string;
+    let body: string;
+    let notificationUrl: string | null;
 
     if (count === 1) {
-      const notification = notifications.find((obj) => obj.length > 0)[0];
+      const notification: Notification = notifications.find(
+        (obj) => obj.length > 0
+      )[0];
       title = `Gitify - ${notification.repository.full_name}`;
       body = notification.subject.title;
       notificationUrl = notification.subject.url;
@@ -42,10 +50,13 @@ export default {
     nativeNotification.onclick = function () {
       if (count === 1) {
         const appWindow = remote.getCurrentWindow();
-        const url = generateGitHubWebUrl(notificationUrl);
-
         appWindow.hide();
-        openExternalLink(url);
+
+        // Some Notification types from GitHub are missing urls in their subjects.
+        if (notificationUrl) {
+          const url = generateGitHubWebUrl(notificationUrl);
+          openExternalLink(url);
+        }
       } else {
         reOpenWindow();
       }


### PR DESCRIPTION
Fixes a console error borne of attempting to create a GitHub url when the `url` property of the `subject` returned with an individual thread in the Notifications thread in the url is not properly populated.

<img width="542" alt="Screen Shot 2020-05-03 at 10 06 04 AM" src="https://user-images.githubusercontent.com/2036040/80920608-bfd5fd00-8d25-11ea-9222-b905cb26231a.png">

Also fixes a few missing types, but i can get rid of that if you'd prefer!

I've raised an issue with the Notifications team within GitHub about the missing urls, so some of them may end up fixed soon 🤞

cc @manosim 