### PR TITLE
feat: add missing mark-read tooltip

### DIFF
--- a/src/js/components/__snapshots__/notification.test.tsx.snap
+++ b/src/js/components/__snapshots__/notification.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`components/notification.js should render itself & its children 1`] = `
     <button
       className="sc-AxgMl beGRRX"
       onClick={[Function]}
+      title="Mark as Read"
     >
       <svg
         aria-hidden="false"

--- a/src/js/components/notification.tsx
+++ b/src/js/components/notification.tsx
@@ -116,7 +116,7 @@ export const NotificationItem: React.FC<IProps> = (props) => {
         </Details>
       </Main>
       <IconWrapper>
-        <Button onClick={() => markAsRead()}>
+        <Button title="Mark as Read" onClick={() => markAsRead()}>
           <Octicon icon={Check} size={20} ariaLabel="Mark as Read" />
         </Button>
       </IconWrapper>


### PR DESCRIPTION
Adds a helpful tooltip for the green check to indicate its function a bit more clearly!

After:

<img width="438" alt="Screen Shot 2020-05-03 at 10 43 39 AM" src="https://user-images.githubusercontent.com/2036040/80921387-f8c4a080-8d2a-11ea-9eb9-c45cfbbe85f0.png">


As an aside, I love this app - thanks for working on it 🙇‍♀️ 