### PR TITLE
feat: enable unsubscribing notifications

### DIFF
--- a/src/js/actions/index.ts
+++ b/src/js/actions/index.ts
@@ -156,6 +156,40 @@ export function markNotification(id, hostname) {
   };
 }
 
+export const UNSUBSCRIBE_NOTIFICATION = makeAsyncActionSet(
+  'UNSUBSCRIBE_NOTIFICATION'
+);
+export function unsubscribeNotification(id, hostname) {
+  return (dispatch, getState: () => AppState) => {
+    const url = `${generateGitHubAPIUrl(
+      hostname
+    )}notifications/threads/${id}/subscription`;
+    const method = 'DELETE';
+
+    const isEnterprise = hostname !== Constants.DEFAULT_AUTH_OPTIONS.hostname;
+    const entAccounts = getState().auth.enterpriseAccounts;
+    const token = isEnterprise
+      ? getEnterpriseAccountToken(hostname, entAccounts)
+      : getState().auth.token;
+
+    dispatch({ type: UNSUBSCRIBE_NOTIFICATION.REQUEST });
+
+    return apiRequestAuth(url, method, token, {})
+      .then(function (response) {
+        dispatch({
+          type: UNSUBSCRIBE_NOTIFICATION.SUCCESS,
+          meta: { id, hostname },
+        });
+      })
+      .catch(function (error) {
+        dispatch({
+          type: UNSUBSCRIBE_NOTIFICATION.FAILURE,
+          payload: error.response.data,
+        });
+      });
+  };
+}
+
 // Repo's Notification
 
 export const MARK_REPO_NOTIFICATION = makeAsyncActionSet(

--- a/src/js/actions/index.ts
+++ b/src/js/actions/index.ts
@@ -18,6 +18,14 @@ export function makeAsyncActionSet(actionName) {
   };
 }
 
+enum Methods {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  PATCH = 'PATCH',
+  DELETE = 'DELETE',
+}
+
 // Authentication
 
 export const LOGIN = makeAsyncActionSet('LOGIN');
@@ -27,7 +35,6 @@ export function loginUser(authOptions, code) {
 
   return (dispatch) => {
     const url = `https://${hostname}/login/oauth/access_token`;
-    const method = 'POST';
     const data = {
       client_id: authOptions.clientId,
       client_secret: authOptions.clientSecret,
@@ -36,7 +43,7 @@ export function loginUser(authOptions, code) {
 
     dispatch({ type: LOGIN.REQUEST });
 
-    return apiRequest(url, method, data)
+    return apiRequest(url, Methods.POST, data)
       .then(function (response) {
         dispatch({
           type: LOGIN.SUCCESS,
@@ -60,7 +67,6 @@ export function logout(): LogoutAction {
 export const NOTIFICATIONS = makeAsyncActionSet('NOTIFICATIONS');
 export function fetchNotifications() {
   return (dispatch, getState: () => AppState) => {
-    const method = 'GET';
     const { settings }: { settings: SettingsState } = getState();
     const isGitHubLoggedIn = getState().auth.token !== null;
     const endpointSuffix = `notifications?participating=${settings.participating}`;
@@ -72,7 +78,7 @@ export function fetchNotifications() {
 
       const url = `https://api.${Constants.DEFAULT_AUTH_OPTIONS.hostname}/${endpointSuffix}`;
       const token = getState().auth.token;
-      return apiRequestAuth(url, method, token);
+      return apiRequestAuth(url, Methods.GET, token);
     }
 
     function getEnterpriseNotifications() {
@@ -81,7 +87,7 @@ export function fetchNotifications() {
         const hostname = account.hostname;
         const token = account.token;
         const url = `https://${hostname}/api/v3/${endpointSuffix}`;
-        return apiRequestAuth(url, method, token);
+        return apiRequestAuth(url, Methods.GET, token);
       });
     }
 
@@ -130,7 +136,6 @@ export const MARK_NOTIFICATION = makeAsyncActionSet('MARK_NOTIFICATION');
 export function markNotification(id, hostname) {
   return (dispatch, getState: () => AppState) => {
     const url = `${generateGitHubAPIUrl(hostname)}notifications/threads/${id}`;
-    const method = 'PATCH';
 
     const isEnterprise = hostname !== Constants.DEFAULT_AUTH_OPTIONS.hostname;
     const entAccounts = getState().auth.enterpriseAccounts;
@@ -140,7 +145,7 @@ export function markNotification(id, hostname) {
 
     dispatch({ type: MARK_NOTIFICATION.REQUEST });
 
-    return apiRequestAuth(url, method, token, {})
+    return apiRequestAuth(url, Methods.PATCH, token, {})
       .then(function (response) {
         dispatch({
           type: MARK_NOTIFICATION.SUCCESS,
@@ -161,10 +166,12 @@ export const UNSUBSCRIBE_NOTIFICATION = makeAsyncActionSet(
 );
 export function unsubscribeNotification(id, hostname) {
   return (dispatch, getState: () => AppState) => {
-    const url = `${generateGitHubAPIUrl(
+    const markReadURL = `${generateGitHubAPIUrl(
+      hostname
+    )}notifications/threads/${id}`;
+    const unsubscribeURL = `${generateGitHubAPIUrl(
       hostname
     )}notifications/threads/${id}/subscription`;
-    const method = 'DELETE';
 
     const isEnterprise = hostname !== Constants.DEFAULT_AUTH_OPTIONS.hostname;
     const entAccounts = getState().auth.enterpriseAccounts;
@@ -174,14 +181,20 @@ export function unsubscribeNotification(id, hostname) {
 
     dispatch({ type: UNSUBSCRIBE_NOTIFICATION.REQUEST });
 
-    return apiRequestAuth(url, method, token, {})
-      .then(function (response) {
+    return apiRequestAuth(unsubscribeURL, Methods.DELETE, token, {})
+      .then((response) => {
+        // The GitHub notifications API doesn't automatically mark things as read
+        // like it does in the UI, so after unsubscribing we also need to hit the
+        // endpoint to mark it as read.
+        return apiRequestAuth(markReadURL, Methods.PATCH, token, {});
+      })
+      .then((response) => {
         dispatch({
           type: UNSUBSCRIBE_NOTIFICATION.SUCCESS,
           meta: { id, hostname },
         });
       })
-      .catch(function (error) {
+      .catch((error) => {
         dispatch({
           type: UNSUBSCRIBE_NOTIFICATION.FAILURE,
           payload: error.response.data,
@@ -200,7 +213,6 @@ export function markRepoNotifications(repoSlug, hostname) {
     const url = `${generateGitHubAPIUrl(
       hostname
     )}repos/${repoSlug}/notifications`;
-    const method = 'PUT';
 
     const isEnterprise = hostname !== Constants.DEFAULT_AUTH_OPTIONS.hostname;
     const entAccounts = getState().auth.enterpriseAccounts;
@@ -210,7 +222,7 @@ export function markRepoNotifications(repoSlug, hostname) {
 
     dispatch({ type: MARK_REPO_NOTIFICATION.REQUEST });
 
-    return apiRequestAuth(url, method, token, {})
+    return apiRequestAuth(url, Methods.PUT, token, {})
       .then(function (response) {
         dispatch({
           type: MARK_REPO_NOTIFICATION.SUCCESS,

--- a/src/js/components/__snapshots__/notification.test.tsx.snap
+++ b/src/js/components/__snapshots__/notification.test.tsx.snap
@@ -59,6 +59,38 @@ exports[`components/notification.js should render itself & its children 1`] = `
     <button
       className="sc-AxgMl beGRRX"
       onClick={[Function]}
+      title="Unsubscribe"
+    >
+      <svg
+        aria-hidden="false"
+        aria-label="Unsubscribe"
+        className="octicon"
+        height={20}
+        role="img"
+        style={
+          Object {
+            "display": "inline-block",
+            "fill": "currentColor",
+            "userSelect": "none",
+            "verticalAlign": "text-bottom",
+          }
+        }
+        viewBox="0 0 16 16"
+        width={20}
+      >
+        <path
+          d="M8 2.81v10.38c0 .67-.81 1-1.28.53L3 10H1c-.55 0-1-.45-1-1V7c0-.55.45-1 1-1h2l3.72-3.72C7.19 1.81 8 2.14 8 2.81zm7.53 3.22l-1.06-1.06-1.97 1.97-1.97-1.97-1.06 1.06L11.44 8 9.47 9.97l1.06 1.06 1.97-1.97 1.97 1.97 1.06-1.06L13.56 8l1.97-1.97z"
+          fillRule="evenodd"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    className="sc-AxhUy cNkvzS"
+  >
+    <button
+      className="sc-AxgMl beGRRX"
+      onClick={[Function]}
       title="Mark as Read"
     >
       <svg

--- a/src/js/components/__snapshots__/notification.test.tsx.snap
+++ b/src/js/components/__snapshots__/notification.test.tsx.snap
@@ -51,39 +51,35 @@ exports[`components/notification.js should render itself & its children 1`] = `
        - Updated
        
       in over 3 years
-    </div>
-  </div>
-  <div
-    className="sc-AxhUy cNkvzS"
-  >
-    <button
-      className="sc-AxgMl beGRRX"
-      onClick={[Function]}
-      title="Unsubscribe"
-    >
-      <svg
-        aria-hidden="false"
-        aria-label="Unsubscribe"
-        className="octicon"
-        height={20}
-        role="img"
-        style={
-          Object {
-            "display": "inline-block",
-            "fill": "currentColor",
-            "userSelect": "none",
-            "verticalAlign": "text-bottom",
-          }
-        }
-        viewBox="0 0 16 16"
-        width={20}
+      <button
+        className="sc-AxheI hMkKFy"
+        onClick={[Function]}
+        title="Unsubscribe"
       >
-        <path
-          d="M8 2.81v10.38c0 .67-.81 1-1.28.53L3 10H1c-.55 0-1-.45-1-1V7c0-.55.45-1 1-1h2l3.72-3.72C7.19 1.81 8 2.14 8 2.81zm7.53 3.22l-1.06-1.06-1.97 1.97-1.97-1.97-1.06 1.06L11.44 8 9.47 9.97l1.06 1.06 1.97-1.97 1.97 1.97 1.06-1.06L13.56 8l1.97-1.97z"
-          fillRule="evenodd"
-        />
-      </svg>
-    </button>
+        <svg
+          aria-hidden="false"
+          aria-label="Unsubscribe"
+          className="octicon"
+          height={13}
+          role="img"
+          style={
+            Object {
+              "display": "inline-block",
+              "fill": "currentColor",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={13}
+        >
+          <path
+            d="M8 2.81v10.38c0 .67-.81 1-1.28.53L3 10H1c-.55 0-1-.45-1-1V7c0-.55.45-1 1-1h2l3.72-3.72C7.19 1.81 8 2.14 8 2.81zm7.53 3.22l-1.06-1.06-1.97 1.97-1.97-1.97-1.06 1.06L11.44 8 9.47 9.97l1.06 1.06 1.97-1.97 1.97 1.97 1.06-1.06L13.56 8l1.97-1.97z"
+            fillRule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
   <div
     className="sc-AxhUy cNkvzS"

--- a/src/js/components/notification.test.tsx
+++ b/src/js/components/notification.test.tsx
@@ -32,6 +32,7 @@ describe('components/notification.js', () => {
 
     const props = {
       markNotification: jest.fn(),
+      unsubscribeNotification: jest.fn(),
       markOnClick: false,
       notification: notification,
       hostname: 'github.com',
@@ -44,6 +45,7 @@ describe('components/notification.js', () => {
   it('should open a notification in the browser', () => {
     const props = {
       markNotification: jest.fn(),
+      unsubscribeNotification: jest.fn(),
       markOnClick: false,
       notification: notification,
       hostname: 'github.com',
@@ -54,22 +56,10 @@ describe('components/notification.js', () => {
     expect(shell.openExternal).toHaveBeenCalledTimes(1);
   });
 
-  it('should mark a notification as read', () => {
-    const props = {
-      markNotification: jest.fn(),
-      markOnClick: false,
-      notification: notification,
-      hostname: 'github.com',
-    };
-
-    const { getByRole } = render(<NotificationItem {...props} />);
-    fireEvent.click(getByRole('button'));
-    expect(props.markNotification).toHaveBeenCalledTimes(1);
-  });
-
   it('should open a notification in browser & mark it as read', () => {
     const props = {
       markNotification: jest.fn(),
+      unsubscribeNotification: jest.fn(),
       markOnClick: true,
       notification: notification,
       hostname: 'github.com',
@@ -79,5 +69,33 @@ describe('components/notification.js', () => {
     fireEvent.click(getByRole('main'));
     expect(shell.openExternal).toHaveBeenCalledTimes(1);
     expect(props.markNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('should mark a notification as read', () => {
+    const props = {
+      markNotification: jest.fn(),
+      unsubscribeNotification: jest.fn(),
+      markOnClick: false,
+      notification: notification,
+      hostname: 'github.com',
+    };
+
+    const { getByLabelText } = render(<NotificationItem {...props} />);
+    fireEvent.click(getByLabelText('Mark as Read'));
+    expect(props.markNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('should unsubscribe from a notification thread', () => {
+    const props = {
+      markNotification: jest.fn(),
+      unsubscribeNotification: jest.fn(),
+      markOnClick: false,
+      notification: notification,
+      hostname: 'github.com',
+    };
+
+    const { getByLabelText } = render(<NotificationItem {...props} />);
+    fireEvent.click(getByLabelText('Unsubscribe'));
+    expect(props.unsubscribeNotification).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/js/components/notification.tsx
+++ b/src/js/components/notification.tsx
@@ -3,7 +3,7 @@ const { shell } = require('electron');
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { formatDistanceToNow, parseISO } from 'date-fns';
-import Octicon, { Check, getIconByName } from '@primer/octicons-react';
+import Octicon, { Check, Mute, getIconByName } from '@primer/octicons-react';
 import styled from 'styled-components';
 
 import { AppState } from '../../types/reducers';
@@ -67,6 +67,7 @@ interface IProps {
   notification: Notification;
   markOnClick: boolean;
   markNotification: (id: string, hostname: string) => void;
+  unsubscribeNotification?: (id: string, hostname: string) => void;
 }
 
 export const NotificationItem: React.FC<IProps> = (props) => {
@@ -89,6 +90,11 @@ export const NotificationItem: React.FC<IProps> = (props) => {
   const markAsRead = () => {
     const { hostname, notification } = props;
     props.markNotification(notification.id, hostname);
+  };
+
+  const unsubscribe = () => {
+    const { hostname, notification } = props;
+    props.unsubscribeNotification(notification.id, hostname);
   };
 
   const { notification } = props;
@@ -115,6 +121,11 @@ export const NotificationItem: React.FC<IProps> = (props) => {
           {updatedAt}
         </Details>
       </Main>
+      <IconWrapper>
+        <Button title="Unsubscribe" onClick={() => unsubscribe()}>
+          <Octicon icon={Mute} size={20} ariaLabel="Unsubscribe" />
+        </Button>
+      </IconWrapper>
       <IconWrapper>
         <Button title="Mark as Read" onClick={() => markAsRead()}>
           <Octicon icon={Check} size={20} ariaLabel="Mark as Read" />

--- a/src/js/components/notification.tsx
+++ b/src/js/components/notification.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { AppState } from '../../types/reducers';
 import { formatReason, getNotificationTypeIcon } from '../utils/github-api';
 import { generateGitHubWebUrl } from '../utils/helpers';
-import { markNotification } from '../actions';
+import { markNotification, unsubscribeNotification } from '../actions';
 import { Notification } from '../../types/github';
 
 const Wrapper = styled.div`
@@ -52,12 +52,23 @@ const IconWrapper = styled.div`
   align-items: center;
 `;
 
-const Button = styled.button`
+const PrimaryButton = styled.button`
   background: none;
   border: none;
 
   .octicon:hover {
     color: ${(props) => props.theme.success};
+    cursor: pointer;
+  }
+`;
+
+const SecondaryButton = styled.button`
+  background: none;
+  border: none;
+  float: right;
+
+  .octicon:hover {
+    color: ${(props) => props.theme.danger};
     cursor: pointer;
   }
 `;
@@ -92,7 +103,10 @@ export const NotificationItem: React.FC<IProps> = (props) => {
     props.markNotification(notification.id, hostname);
   };
 
-  const unsubscribe = () => {
+  const unsubscribe = (event: React.MouseEvent<HTMLElement>) => {
+    // Don't trigger onClick of parent element.
+    event.stopPropagation();
+
     const { hostname, notification } = props;
     props.unsubscribeNotification(notification.id, hostname);
   };
@@ -119,15 +133,15 @@ export const NotificationItem: React.FC<IProps> = (props) => {
         <Details>
           <span title={reason.description}>{reason.type}</span> - Updated{' '}
           {updatedAt}
-          <Button title="Unsubscribe" onClick={() => unsubscribe()}>
+          <SecondaryButton title="Unsubscribe" onClick={(e) => unsubscribe(e)}>
             <Octicon icon={Mute} size={13} ariaLabel="Unsubscribe" />
-          </Button>
+          </SecondaryButton>
         </Details>
       </Main>
       <IconWrapper>
-        <Button title="Mark as Read" onClick={() => markAsRead()}>
+        <PrimaryButton title="Mark as Read" onClick={() => markAsRead()}>
           <Octicon icon={Check} size={20} ariaLabel="Mark as Read" />
-        </Button>
+        </PrimaryButton>
       </IconWrapper>
     </Wrapper>
   );
@@ -139,4 +153,7 @@ export function mapStateToProps(state: AppState) {
   };
 }
 
-export default connect(mapStateToProps, { markNotification })(NotificationItem);
+export default connect(mapStateToProps, {
+  markNotification,
+  unsubscribeNotification,
+})(NotificationItem);

--- a/src/js/components/notification.tsx
+++ b/src/js/components/notification.tsx
@@ -119,13 +119,11 @@ export const NotificationItem: React.FC<IProps> = (props) => {
         <Details>
           <span title={reason.description}>{reason.type}</span> - Updated{' '}
           {updatedAt}
+          <Button title="Unsubscribe" onClick={() => unsubscribe()}>
+            <Octicon icon={Mute} size={13} ariaLabel="Unsubscribe" />
+          </Button>
         </Details>
       </Main>
-      <IconWrapper>
-        <Button title="Unsubscribe" onClick={() => unsubscribe()}>
-          <Octicon icon={Mute} size={20} ariaLabel="Unsubscribe" />
-        </Button>
-      </IconWrapper>
       <IconWrapper>
         <Button title="Mark as Read" onClick={() => markAsRead()}>
           <Octicon icon={Check} size={20} ariaLabel="Mark as Read" />

--- a/src/js/middleware/notifications.ts
+++ b/src/js/middleware/notifications.ts
@@ -3,6 +3,7 @@ import {
   NOTIFICATIONS,
   MARK_NOTIFICATION,
   MARK_REPO_NOTIFICATION,
+  UNSUBSCRIBE_NOTIFICATION,
 } from '../actions';
 import NativeNotifications from '../utils/notifications';
 import { updateTrayIcon } from '../utils/comms';
@@ -56,6 +57,7 @@ export default (store) => (next) => (action) => {
       break;
 
     case MARK_NOTIFICATION.SUCCESS:
+    case UNSUBSCRIBE_NOTIFICATION.SUCCESS:
       const prevNotificationsCount = accountNotifications.reduce(
         (memo, acc) => memo + acc.notifications.length,
         0

--- a/src/js/reducers/notifications.ts
+++ b/src/js/reducers/notifications.ts
@@ -3,6 +3,7 @@ import {
   NOTIFICATIONS,
   MARK_NOTIFICATION,
   MARK_REPO_NOTIFICATION,
+  UNSUBSCRIBE_NOTIFICATION,
 } from '../actions';
 import { LOGOUT } from '../../types/actions';
 import { Notification } from '../../types/github';
@@ -26,6 +27,7 @@ export default function reducer(
     case NOTIFICATIONS.FAILURE:
       return { ...state, isFetching: false, failed: true, response: [] };
     case MARK_NOTIFICATION.SUCCESS:
+    case UNSUBSCRIBE_NOTIFICATION.SUCCESS:
       const accountIndex = state.response.findIndex(
         (obj) => obj.hostname === action.meta.hostname
       );


### PR DESCRIPTION
Closes https://github.com/manosim/gitify/issues/402.

When the new unsubscribe icon is clicked, all future notifications for a conversation are muted until one comments on the thread or gets an @mention.

<img width="612" alt="Screen Shot 2020-05-04 at 4 32 02 PM" src="https://user-images.githubusercontent.com/2036040/81028543-c99b5580-8e36-11ea-803b-1d935ecede6f.png">

cc @manosim 