### PR TITLE
fix: use thread subscription set endpoint

### DIFF
--- a/src/js/actions/index.test.ts
+++ b/src/js/actions/index.test.ts
@@ -379,7 +379,7 @@ describe('actions/index.js', () => {
 
     // The unsubscribe endpoint call.
     nock('https://api.github.com/')
-      .delete(`/notifications/threads/${id}/subscription`)
+      .put(`/notifications/threads/${id}/subscription`)
       .reply(204);
 
     // The mark read endpoint call.
@@ -419,7 +419,7 @@ describe('actions/index.js', () => {
     const message = 'Oops! Something went wrong.';
 
     nock('https://api.github.com/')
-      .delete(`/notifications/threads/${id}/subscription`)
+      .put(`/notifications/threads/${id}/subscription`)
       .reply(400, { message });
 
     const expectedActions = [

--- a/src/js/actions/index.ts
+++ b/src/js/actions/index.ts
@@ -181,7 +181,7 @@ export function unsubscribeNotification(id, hostname) {
 
     dispatch({ type: UNSUBSCRIBE_NOTIFICATION.REQUEST });
 
-    return apiRequestAuth(unsubscribeURL, Methods.DELETE, token, {})
+    return apiRequestAuth(unsubscribeURL, Methods.PUT, token, { ignore: true })
       .then((response) => {
         // The GitHub notifications API doesn't automatically mark things as read
         // like it does in the UI, so after unsubscribing we also need to hit the


### PR DESCRIPTION
As I used the new unsubscribe feature, I discovered an annoying little idiosyncrasy - the [set thread subscription](https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription) endpoint encompasses more thorough functionality than the [delete thread subscription](https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription) endpoint.

Essentially - both endpoints can mute all future notifications for a conversation until you comment on the thread or get an @mention. _However_, the delete endpoint includes this caveat:

> If you are watching the repository of the thread, you will still receive notifications.

Which sort of nerfs a lot of the reasons one would unsubscribe from a notification in the first place. To unsubscribe regardless of watch status, one should actually hit the set thread subscription endpoint with a PUT call and pass `ignore: true` in the call body, which is what this PR does.

cc @manosim 