### PR TITLE
feat: move to app folder on first run

### DIFF
--- a/first-run.js
+++ b/first-run.js
@@ -1,0 +1,54 @@
+const { app, dialog } = require('electron');
+
+const fs = require('fs-extra');
+const path = require('path');
+
+async function onFirstRunMaybe() {
+  if (isFirstRun()) {
+    await promptMoveToApplicationsFolder();
+  }
+}
+
+// Ask user if the app should be moved to the applications folder.
+async function promptMoveToApplicationsFolder() {
+  if (process.platform !== 'darwin') return;
+
+  const isDevMode = !!process.defaultApp;
+  if (isDevMode || app.isInApplicationsFolder()) return;
+
+  const { response } = await dialog.showMessageBox({
+    type: 'question',
+    buttons: ['Move to Applications Folder', 'Do Not Move'],
+    defaultId: 0,
+    message: 'Move to Applications Folder?',
+  });
+
+  if (response === 0) {
+    app.moveToApplicationsFolder();
+  }
+}
+
+const getConfigPath = () => {
+  const userDataPath = app.getPath('userData');
+  return path.join(userDataPath, 'FirstRun', 'gitify-first-run');
+};
+
+// Whether or not the app is being run for the first time.
+function isFirstRun() {
+  const configPath = getConfigPath();
+
+  try {
+    if (fs.existsSync(configPath)) {
+      return false;
+    }
+
+    fs.outputFileSync(configPath, '');
+  } catch (error) {
+    console.warn(`First run: Unable to write firstRun file`, error);
+  }
+
+  return true;
+}
+
+module.exports = { onFirstRunMaybe }
+

--- a/main.js
+++ b/main.js
@@ -1,11 +1,11 @@
-const { ipcMain } = require('electron');
+const { ipcMain, app } = require('electron');
 const { menubar } = require('menubar');
 const { autoUpdater } = require('electron-updater');
+const { onFirstRunMaybe } = require('./first-run');
 const path = require('path');
 
 const iconIdle = path.join(__dirname, 'assets', 'images', 'tray-idleTemplate.png');
 const iconActive = path.join(__dirname, 'assets', 'images', 'tray-active.png');
-const isDarwin = process.platform === 'darwin';
 
 const browserWindowOpts = {
   width: 500,
@@ -18,6 +18,10 @@ const browserWindowOpts = {
     nodeIntegration: true,
   },
 };
+
+app.on('ready', async () => {
+  await onFirstRunMaybe();
+})
 
 const menubarApp = menubar({
   icon: iconIdle,

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
       "assets/**/*",
       "index.html",
       "LICENSE",
-      "main.js"
+      "main.js",
+      "first-run.js"
     ],
     "mac": {
       "category": "public.app-category.developer-tools",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "typeRoots": ["./src/types", "node_modules/@types"]
   },
   "exclude": ["node_modules"],
-  "include": ["src/**/*.js", "src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.js", "src/**/*.ts", "src/**/*.tsx", "first-run.js", "main.js"]
 }


### PR DESCRIPTION
Closes https://github.com/manosim/gitify/issues/417.

When gitify first opens, it will now request to move itself to the Applications folder on macOS. The user's choice will be stored for subsequent runs. If it's _already_ in the Applications folder, no prompts are shown.

cc @manosim I pulled the functionality into a new file but if you'd prefer I can put it into `main.js` or do something else entirely with it, up to you!