### PR TITLE
Refactor to use prettier config file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
-trailingComma: "es5"
+trailingComma: 'es5'
 tabWidth: 2
 semi: true
 singleQuote: true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "make:macos": "electron-builder --mac",
     "make:win": "electron-builder --win",
     "prettier-check": "prettier --check 'src/**/*.{js,ts,tsx}'",
-    "prettier": "prettier --single-quote --trailing-comma es5 --write 'src/**/*.{js,ts,tsx}'",
+    "prettier": "prettier --write 'src/**/*.{js,ts,tsx}'",
     "jest": "jest",
     "test": "yarn jest",
     "start": "electron . -–enable-logging"


### PR DESCRIPTION
👋  Hello! First off I would like to thank you for making this. It's super useful! This PR removes the flags passed into the prettier command located in `package.json`. Because it is already defined in the config file passing it in as flags is just redundant.