### PR TITLE
fix: add missing Discussions data

### DIFF
--- a/src/js/utils/github-api.test.ts
+++ b/src/js/utils/github-api.test.ts
@@ -19,14 +19,15 @@ describe('./utils/github-api.ts', () => {
   });
 
   it('should get the notification type icon', () => {
+    expect(getNotificationTypeIcon('CheckSuite')).toBe('sync');
+    expect(getNotificationTypeIcon('Commit')).toBe('git-commit');
+    expect(getNotificationTypeIcon('Discussion')).toBe('comment-discussion');
     expect(getNotificationTypeIcon('Issue')).toBe('issue-opened');
     expect(getNotificationTypeIcon('PullRequest')).toBe('git-pull-request');
-    expect(getNotificationTypeIcon('Commit')).toBe('git-commit');
     expect(getNotificationTypeIcon('Release')).toBe('tag');
     expect(getNotificationTypeIcon('RepositoryVulnerabilityAlert')).toBe(
       'alert'
     );
-    expect(getNotificationTypeIcon('CheckSuite')).toBe('sync');
     expect(getNotificationTypeIcon('Unknown' as SubjectType)).toBe('question');
   });
 });

--- a/src/js/utils/github-api.ts
+++ b/src/js/utils/github-api.ts
@@ -53,18 +53,20 @@ export function formatReason(
 
 export function getNotificationTypeIcon(type: SubjectType): string {
   switch (type) {
+    case 'CheckSuite':
+      return 'sync';
+    case 'Commit':
+      return 'git-commit';
+    case 'Discussion':
+      return 'comment-discussion';
     case 'Issue':
       return 'issue-opened';
     case 'PullRequest':
       return 'git-pull-request';
-    case 'Commit':
-      return 'git-commit';
     case 'Release':
       return 'tag';
     case 'RepositoryVulnerabilityAlert':
       return 'alert';
-    case 'CheckSuite':
-      return 'sync';
     default:
       return 'question';
   }

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -13,11 +13,12 @@ export type Reason =
   | 'ci_activity';
 
 export type SubjectType =
+  | 'CheckSuite'
+  | 'Commit'
+  | 'Discussion'
   | 'Issue'
   | 'PullRequest'
-  | 'Commit'
   | 'Release'
-  | 'CheckSuite'
   | 'RepositoryVulnerabilityAlert';
 
 export interface Notification {


### PR DESCRIPTION
Adds missing icon data for GitHub Discussions.

Before:

<img width="487" alt="Screen Shot 2020-10-16 at 10 25 47 AM" src="https://user-images.githubusercontent.com/2036040/96289502-077dd780-0f9a-11eb-9540-1036c202080e.png">

After:

<img width="481" alt="Screen Shot 2020-10-16 at 10 24 40 AM" src="https://user-images.githubusercontent.com/2036040/96289509-0b115e80-0f9a-11eb-93ed-6f8fd8ca66f2.png">

cc @manosim 