### PR TITLE
Remove ok hand emoji

### DIFF
--- a/src/js/utils/constants.tsx
+++ b/src/js/utils/constants.tsx
@@ -32,7 +32,6 @@ export default {
     ':clap:',
     ':circus_tent:',
     ':spaghetti:',
-    ':ok_hand:',
   ],
 
   ERROR_EMOJIS: [


### PR DESCRIPTION
Unfortunately this emoji has been used as a symbol of hate by some groups so it's probably best to remove it.