### PR TITLE
feat: Hide app's dock icon

### DIFF
--- a/first-run.js
+++ b/first-run.js
@@ -50,5 +50,4 @@ function isFirstRun() {
   return true;
 }
 
-module.exports = { onFirstRunMaybe }
-
+module.exports = { onFirstRunMaybe };

--- a/main.js
+++ b/main.js
@@ -4,7 +4,12 @@ const { autoUpdater } = require('electron-updater');
 const { onFirstRunMaybe } = require('./first-run');
 const path = require('path');
 
-const iconIdle = path.join(__dirname, 'assets', 'images', 'tray-idleTemplate.png');
+const iconIdle = path.join(
+  __dirname,
+  'assets',
+  'images',
+  'tray-idleTemplate.png'
+);
 const iconActive = path.join(__dirname, 'assets', 'images', 'tray-active.png');
 
 const browserWindowOpts = {
@@ -23,7 +28,7 @@ const browserWindowOpts = {
 
 app.on('ready', async () => {
   await onFirstRunMaybe();
-})
+});
 
 const menubarApp = menubar({
   icon: iconIdle,

--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ const browserWindowOpts = {
     enableRemoteModule: true,
     overlayScrollbars: true,
     nodeIntegration: true,
+    contextIsolation: false,
   },
 };
 
@@ -63,4 +64,8 @@ menubarApp.on('ready', () => {
     menubarApp.positioner.move('trayCenter', trayBounds);
     menubarApp.window.resizable = false;
   });
+});
+
+menubarApp.on('after-create-window', () => {
+  app.dock.hide();
 });

--- a/main.js
+++ b/main.js
@@ -26,6 +26,13 @@ const browserWindowOpts = {
   },
 };
 
+const delayedHideAppIcon = () =>
+  // Setting a timeout because the showDockIcon is not currently working
+  // See more at https://github.com/maxogden/menubar/issues/306
+  setTimeout(() => {
+    app.dock.hide();
+  }, 1500);
+
 app.on('ready', async () => {
   await onFirstRunMaybe();
 });
@@ -38,6 +45,8 @@ const menubarApp = menubar({
 });
 
 menubarApp.on('ready', () => {
+  delayedHideAppIcon();
+
   menubarApp.tray.setIgnoreDoubleClickEvents(true);
 
   autoUpdater.checkForUpdatesAndNotify();
@@ -69,8 +78,4 @@ menubarApp.on('ready', () => {
     menubarApp.positioner.move('trayCenter', trayBounds);
     menubarApp.window.resizable = false;
   });
-});
-
-menubarApp.on('after-create-window', () => {
-  app.dock.hide();
 });


### PR DESCRIPTION
Since we updated Electron, the `menubar` fails to handle the `showDockIcon` flag. This PR has a temporary workaround by calling `menubarApp.app.dock.hide()` when the window has been created.

See https://github.com/maxogden/menubar/issues/306 for more.