### PR TITLE
fix: Hide dock icon only for macOS

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,13 +26,6 @@ const browserWindowOpts = {
   },
 };
 
-const delayedHideAppIcon = () =>
-  // Setting a timeout because the showDockIcon is not currently working
-  // See more at https://github.com/maxogden/menubar/issues/306
-  setTimeout(() => {
-    app.dock.hide();
-  }, 1500);
-
 app.on('ready', async () => {
   await onFirstRunMaybe();
 });
@@ -45,7 +38,9 @@ const menubarApp = menubar({
 });
 
 menubarApp.on('ready', () => {
-  delayedHideAppIcon();
+  if (app.dock && app.dock.hide) {
+    app.dock.hide();
+  }
 
   menubarApp.tray.setIgnoreDoubleClickEvents(true);
 

--- a/main.js
+++ b/main.js
@@ -26,6 +26,16 @@ const browserWindowOpts = {
   },
 };
 
+const delayedHideAppIcon = () => {
+  if (app.dock && app.dock.hide) {
+    // Setting a timeout because the showDockIcon is not currently working
+    // See more at https://github.com/maxogden/menubar/issues/306
+    setTimeout(() => {
+      app.dock.hide();
+    }, 1500);
+  }
+};
+
 app.on('ready', async () => {
   await onFirstRunMaybe();
 });
@@ -38,9 +48,7 @@ const menubarApp = menubar({
 });
 
 menubarApp.on('ready', () => {
-  if (app.dock && app.dock.hide) {
-    app.dock.hide();
-  }
+  delayedHideAppIcon();
 
   menubarApp.tray.setIgnoreDoubleClickEvents(true);
 

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@types/react-transition-group": "^4.2.4",
     "@types/styled-components": "^5.0.1",
     "css-loader": "^5.0.1",
-    "electron": "^11.0.2",
+    "electron": "^11.1.0",
     "electron-builder": "^22.9.1",
     "electron-notarize": "^1.0.0",
     "jest": "^26.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,10 +2215,10 @@ electron-updater@^4.3.5:
     lodash.isequal "^4.5.0"
     semver "^7.3.2"
 
-electron@^11.0.2:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.0.2.tgz#c7bd2b9abdc1446f4578dbfa22573014b6b2df58"
-  integrity sha512-FTYtCm0oj8B8EJhp99BQSW2bd40xYEG/txMj+W3Ed0CNu5zVIIXb5WIrhXLvhcasN5LKy9nkmSZ+u220lCaARg==
+electron@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.1.0.tgz#8dfdf579d1eb79feef3e3d2937fc022e72129c90"
+  integrity sha512-RFAhR/852VMaRd9NSe7jprwSoG9dLc6u1GwnqRWg+/3cy/8Zrwt1Betw1lXiZH7hGuB9K2cqju83Xv5Pq5ZSGA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
Call `app.dock.hide()` only if `hide()` exists.

Closes #451.