### PR TITLE
Prevent repos from growing to fill the screen

### DIFF
--- a/src/js/components/__snapshots__/repository.test.tsx.snap
+++ b/src/js/components/__snapshots__/repository.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/repository.tsx should render itself & its children 1`] = `
 Array [
   <div
-    className="flex flex-1 p-2 bg-gray-100 dark:bg-gray-darker dark:text-white"
+    className="flex flex-1 flex-grow-0 p-2 bg-gray-100 dark:bg-gray-darker dark:text-white"
   >
     <div
       className="flex flex-1 p-0.5 items-center mt-0 text-sm font-medium overflow-hidden overflow-ellipsis whitespace-nowrap"

--- a/src/js/components/repository.tsx
+++ b/src/js/components/repository.tsx
@@ -33,7 +33,7 @@ export const RepositoryNotifications: React.FC<IProps> = (props) => {
 
   return (
     <>
-      <div className="flex flex-1 p-2 bg-gray-100 dark:bg-gray-darker dark:text-white">
+      <div className="flex flex-1 flex-grow-0 p-2 bg-gray-100 dark:bg-gray-darker dark:text-white">
         <div className="flex flex-1 p-0.5 items-center mt-0 text-sm font-medium overflow-hidden overflow-ellipsis whitespace-nowrap">
           <img className="rounded w-5 h-5 ml-1 mr-3" src={avatarUrl} />
           <span onClick={openBrowser}>{props.repoName}</span>


### PR DESCRIPTION
Fixes #458 #460

<img width="505" alt="Screenshot 2020-12-18 at 11 48 53" src="https://user-images.githubusercontent.com/5850625/102611919-c20b9100-4127-11eb-8f49-b620c597e547.png">
