### PR TITLE
fix: oversized repository lines

### DIFF
--- a/src/js/components/__snapshots__/repository.test.tsx.snap
+++ b/src/js/components/__snapshots__/repository.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/repository.tsx should render itself & its children 1`] = `
 Array [
   <div
-    className="flex flex-1 p-2 bg-gray-100 dark:bg-gray-darker dark:text-white"
+    className="flex flex-initial p-2 bg-gray-100 dark:bg-gray-darker dark:text-white"
   >
     <div
       className="flex flex-1 p-0.5 items-center mt-0 text-sm font-medium overflow-hidden overflow-ellipsis whitespace-nowrap"

--- a/src/js/components/repository.tsx
+++ b/src/js/components/repository.tsx
@@ -33,7 +33,7 @@ export const RepositoryNotifications: React.FC<IProps> = (props) => {
 
   return (
     <>
-      <div className="flex flex-1 p-2 bg-gray-100 dark:bg-gray-darker dark:text-white">
+      <div className="flex flex-initial p-2 bg-gray-100 dark:bg-gray-darker dark:text-white">
         <div className="flex flex-1 p-0.5 items-center mt-0 text-sm font-medium overflow-hidden overflow-ellipsis whitespace-nowrap">
           <img className="rounded w-5 h-5 ml-1 mr-3" src={avatarUrl} />
           <span onClick={openBrowser}>{props.repoName}</span>


### PR DESCRIPTION
Heya! 👋 

There might be raised in a few places but this relates to #458. I noticed that we moved to tailwind recently so I think this was just a small bug from that refactor. 

What I've done here is set the flex of the repository item to `flex-initial` which is equivalent to `flex: 0 1 auto;` it lets the items shrink but not grow beyond their size. Hopefully this should do the job, it seems to work fine from my limited testing but you may want to give it a razz too!

This is my first contribution here so let me know if you want anything changed, thats no worries 🙂 