### PR TITLE
docs: Fix installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 You can download Gitify for **free** from the website [www.gitify.io](https://www.gitify.io/) or install it via [Homebrew Cask](http://brew.sh/).
 
 ```shell
-brew cask install gitify
+brew install --cask gitify
 ```
 
 Gitify supports macOS, Windows and Linux.


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but readme needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103261302-66bd8680-49e4-11eb-9a42-2396e512be74.png)
