### PR TITLE
chore: Remove previous auto-update config

### DIFF
--- a/auto_updater.json
+++ b/auto_updater.json
@@ -1,4 +1,0 @@
-{
-  "name": "Release 3.0.0",
-  "url": "https://github.com/manosim/gitify/releases/download/v3.0.0/gitify-osx.zip"
-}


### PR DESCRIPTION
This was used before v3 and since we've now moved to using `electron-updater`, we can now safely delete it.