### PR TITLE
Add underscore to allowed characters for personal access tokens

### DIFF
--- a/src/routes/LoginWithToken.tsx
+++ b/src/routes/LoginWithToken.tsx
@@ -23,7 +23,7 @@ export const validate = (values: IValues): IFormErrors => {
   const errors: IFormErrors = {};
   if (!values.token) {
     errors.token = 'Required';
-  } else if (!/^[A-Z0-9]{40}$/i.test(values.token)) {
+  } else if (!/^[A-Z0-9_]{40}$/i.test(values.token)) {
     errors.token = 'Invalid token.';
   }
 


### PR DESCRIPTION
GitHub has a [new token format](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/) which introduces `_` as an allowed character. 

Fixes #491 