### PR TITLE
fix: dark mode not toggling with system

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { ipcMain, app } = require('electron');
+const { ipcMain, app, nativeTheme } = require('electron');
 const { menubar } = require('menubar');
 const { autoUpdater } = require('electron-updater');
 const { onFirstRunMaybe } = require('./first-run');
@@ -53,6 +53,14 @@ menubarApp.on('ready', () => {
   menubarApp.tray.setIgnoreDoubleClickEvents(true);
 
   autoUpdater.checkForUpdatesAndNotify();
+
+  nativeTheme.on('updated', () => {
+    if (nativeTheme.shouldUseDarkColors) {
+      menubarApp.window.webContents.send('update-native-theme', 'DARK');
+    } else {
+      menubarApp.window.webContents.send('update-native-theme', 'LIGHT');
+    }
+  });
 
   ipcMain.on('reopen-window', () => menubarApp.showWindow());
   ipcMain.on('app-quit', () => menubarApp.app.quit());

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -11,12 +11,19 @@ import { IconAddAccount } from '../icons/AddAccount';
 import { IconLogOut } from '../icons/Logout';
 import { IconQuit } from '../icons/Quit';
 import { updateTrayIcon } from '../utils/comms';
+import { setAppearance } from '../utils/appearance';
 
 const isLinux = remote.process.platform === 'linux';
 
 export const SettingsRoute: React.FC = () => {
   const { settings, updateSetting, logout } = useContext(AppContext);
   const history = useHistory();
+
+  ipcRenderer.on('update-native-theme', (_, updatedAppearance: Appearance) => {
+    if (settings.appearance === Appearance.SYSTEM) {
+      setAppearance(updatedAppearance);
+    }
+  });
 
   const logoutUser = useCallback(() => {
     logout();


### PR DESCRIPTION
Closes https://github.com/manosim/gitify/issues/496.

Fixes an issue that could occur when the theme was set to `System`. In this case, if the user updated dark mode on their OS, the theme wouldn't update in the app unless it was quit and opened again. Fix this by using `nativeTheme` to listen for system theme changes and update the UI accordingly.