### PR TITLE
fix: unsubscribe button ignoring thread subscription

### DIFF
--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -158,7 +158,7 @@ export const useNotifications = (): NotificationsState => {
           )}notifications/threads/${id}/subscription`,
           'PUT',
           token,
-          { ignore: true }
+          { ignored: true }
         );
         await markNotification(accounts, id, hostname);
       } catch (err) {


### PR DESCRIPTION
Closes https://github.com/manosim/gitify/issues/421

The unsubscribe button isn't actually updating the subscription. From [here](https://docs.github.com/en/rest/reference/activity#set-a-thread-subscription) it appears the key should be `ignored` rather than `ignore` (even though [right below](https://docs.github.com/en/rest/reference/activity#delete-a-thread-subscription) mentions `ignore`). 