### PR TITLE
Fix Personal Access Token login method to Github Enterprise Server modifying getUserData

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -113,8 +113,8 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   const login = useCallback(async () => {
     const { authCode } = await authGitHub();
     const { token } = await getToken(authCode);
-    const user = await getUserData(token);
     const hostname = Constants.DEFAULT_AUTH_OPTIONS.hostname;
+    const user = await getUserData(token, hostname);
     const updatedAccounts = addAccount(accounts, token, hostname, user);
     setAccounts(updatedAccounts);
     saveState(updatedAccounts, settings);
@@ -138,7 +138,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         'HEAD',
         token
       );
-      const user = await getUserData(token);
+      const user = await getUserData(token, hostname);
       const updatedAccounts = addAccount(accounts, token, hostname, user);
       setAccounts(updatedAccounts);
       saveState(updatedAccounts, settings);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -68,7 +68,10 @@ export const authGitHub = (
   });
 };
 
-export const getUserData = async (token: string, hostname: string): Promise<User> => {
+export const getUserData = async (
+  token: string,
+  hostname: string
+): Promise<User> => {
   const response = await apiRequestAuth(
     `https://api.${hostname}/user`,
     'GET',

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -68,9 +68,9 @@ export const authGitHub = (
   });
 };
 
-export const getUserData = async (token: string): Promise<User> => {
+export const getUserData = async (token: string, hostname: string): Promise<User> => {
   const response = await apiRequestAuth(
-    `https://api.${Constants.DEFAULT_AUTH_OPTIONS.hostname}/user`,
+    `https://api.${hostname}/user`,
     'GET',
     token
   );


### PR DESCRIPTION
Hello, @manosim 

@Uanid fix about Issue #502 to PR #504. But, it is outdated and have conflicts. Also, I think reusing `getUserData` is much better, so I add hostname parameter in `getUserData` method. What do you think about it?
