### PR TITLE
Capture callback by `will-navigate` event

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -65,6 +65,11 @@ export const authGitHub = (
       event.preventDefault();
       handleCallback(url);
     });
+
+    authWindow.webContents.on('will-navigate', (event, url) => {
+      event.preventDefault();
+      handleCallback(url);
+    });
   });
 };
 


### PR DESCRIPTION
Hi, @manosim 

Recently, Github OAuth redirect is changed by meta refresh tag, So it cannot capture auth code from callback url. I added `will-navigate` event capture function, it can help capture auth code from meta refresh tag and login Gitify.