### PR TITLE
fix: add RepositoryInvitation icon

### DIFF
--- a/src/typesGithub.ts
+++ b/src/typesGithub.ts
@@ -19,6 +19,7 @@ export type SubjectType =
   | 'Issue'
   | 'PullRequest'
   | 'Release'
+  | 'RepositoryInvitation'
   | 'RepositoryVulnerabilityAlert';
 
 export interface Notification {

--- a/src/utils/github-api.ts
+++ b/src/utils/github-api.ts
@@ -68,6 +68,8 @@ export function getNotificationTypeIcon(
       return Octicons.GitPullRequestIcon;
     case 'Release':
       return Octicons.TagIcon;
+    case 'RepositoryInvitation':
+      return Octicons.MailIcon;
     case 'RepositoryVulnerabilityAlert':
       return Octicons.AlertIcon;
     default:


### PR DESCRIPTION
Fix missing repository invitation icon.

Before:
<img width="446" alt="Screen Shot 2022-03-17 at 10 46 30 AM" src="https://user-images.githubusercontent.com/2036040/158782819-c4bc5239-d31c-4f36-93bb-a5b9b9f3dfde.png">

After:
![Uploading Screen Shot 2022-03-17 at 10.47.35 AM.png…]()

